### PR TITLE
ci: CD 배포 트리거를 push:[main]으로 변경 (fork PR 머지 배포 실패 수정)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,8 @@
 name: CD - Deploy
 
 on:
-  pull_request:
+  push:
     branches: [main]
-    types: [closed]
   workflow_dispatch:
 
 env:
@@ -12,9 +11,6 @@ env:
 
 jobs:
   build-and-deploy:
-    if: |
-      github.event_name == 'workflow_dispatch' || 
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 문제

포크(fork)에서 온 PR(#147, #148)을 main에 머지하면 CD 배포가 실패한다.

```
denied: installation not allowed to Write organization package
```

- 기존 `cd.yml`은 `pull_request: types:[closed]` + `merged==true`로 "PR 머지 시 배포"하는 구조
- 하지만 **fork發 `pull_request` 이벤트는 closed/merged 여도 `GITHUB_TOKEN`이 read-only로 강제**되고 시크릿도 전달되지 않음 → GHCR 이미지 푸시 denied, Discord 웹훅 `No webhook`
- 같은 저장소(`dev`→main) 머지는 full 권한이라 성공했으나, fork PR에서만 깨짐

## 수정

트리거를 `push: [main]`으로 변경:

- 어떤 PR(포크 포함)이 머지되든 **main에 push되는 순간 base 저장소 권한(packages:write + 시크릿)** 으로 배포 실행
- 죽은 `if` 가드(`pull_request.merged`) 제거

## 효과

이 PR을 main에 머지하는 push가 곧바로 첫 정상 배포를 트리거 → 이미 머지됐지만 배포되지 못한 #147·#148까지 프로덕션에 반영된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)